### PR TITLE
Remove Multidex declaration

### DIFF
--- a/Sources/pushwoosh-firebase/build.gradle
+++ b/Sources/pushwoosh-firebase/build.gradle
@@ -89,7 +89,6 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
 
     testImplementation 'org.robolectric:robolectric:4.13'
-    testImplementation 'org.robolectric:shadows-multidex:4.13'
     testImplementation 'org.robolectric:shadows-httpclient:4.13'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.6.0'

--- a/Sources/pushwoosh/build.gradle
+++ b/Sources/pushwoosh/build.gradle
@@ -97,7 +97,6 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
 
     testImplementation 'org.robolectric:robolectric:4.13'
-    testImplementation 'org.robolectric:shadows-multidex:4.13'
     testImplementation 'org.robolectric:shadows-httpclient:4.13'
 
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.6.0'


### PR DESCRIPTION
Since the min SDK is 23, it is no longer necessary to use the Multidex library.
It has been removed from this project, but it still depends on Robolectric's `shadows-multidex`, which is not necessary.

See the following for more info: https://developer.android.com/build/multidex#mdex-on-l